### PR TITLE
Fix date parsing crash on newer libc

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -148,15 +148,17 @@ int my_mkdir(const std::string& path, int perms)
 char* my_strptime(const char* s,
 	const char* f,
 	struct tm* tm)
-{
+try {
 	std::istringstream input(s);
-	input.imbue(std::locale(setlocale(LC_ALL, nullptr)));
+	input.imbue(std::locale::classic());
 	input >> std::get_time(tm, f);
 	if (input.fail())
 	{
 		return nullptr;
 	}
 	return (char*)(s + input.tellg());
+} catch (...) {
+	return nullptr;
 }
 
 // http://stackoverflow.com/a/11366985

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -149,17 +149,14 @@ char* my_strptime(const char* s,
 	const char* f,
 	struct tm* tm)
 {
-	// just use normal strptime, the DIY implementation was being Weird
-	return strptime(s, f, tm);
-
-	// std::istringstream input(s);
-	// input.imbue(std::locale(setlocale(LC_ALL, nullptr)));
-	// input >> std::get_time(tm, f);
-	// if (input.fail())
-	// {
-	// 	return nullptr;
-	// }
-	// return (char*)(s + input.tellg());
+	std::istringstream input(s);
+	input.imbue(std::locale(setlocale(LC_ALL, nullptr)));
+	input >> std::get_time(tm, f);
+	if (input.fail())
+	{
+		return nullptr;
+	}
+	return (char*)(s + input.tellg());
 }
 
 // http://stackoverflow.com/a/11366985


### PR DESCRIPTION
Since newlib commit e5a9f552ecf908f1639b08729edc191c66f4e7d0, `setlocale(LC_ALL, null)` returns "C/C.UTF-8/C/C/C/C" instead of "C". And libstdc++'s `std::locale(char*)` cannot parse that locale and throws a runtime_error, which corrupts the call stack resulting in a segfault.

To fix this, pass `std::locale::classic()` directly and skip the setlocale business. And if even this fails, catch the exception and fail the
function instead.

Is it likely to throw an exception? Probably not. Ideally I'd exit the entire app cleanly (preferably avoiding a game/applet crash) rather than silently swallowing the exception, but I don't know how...

- Funnily enough the original code was *wrong* since it parsed dates in the user's locale, while we were receiving fixed-format strings from a server-side JSON file, which the user's locale may not be compatible with.
- Are there really platforms with a working `std::istringstream` + `std::get_time`, but no working `strptime`?